### PR TITLE
command parsing test

### DIFF
--- a/librcompose/docker/convert.go
+++ b/librcompose/docker/convert.go
@@ -36,8 +36,14 @@ func Convert(c *project.ServiceConfig) (*runconfig.Config, *runconfig.HostConfig
 		volumes[v] = struct {}{}
 	}
 
-	cmd, _ := shlex.Split(c.Command)
-	entrypoint, _ := shlex.Split(c.Entrypoint)
+	cmd, err := shlex.Split(c.Command)
+	if err != nil {
+		return nil, nil, err
+	}
+	entrypoint, err := shlex.Split(c.Entrypoint)
+	if err != nil {
+		return nil, nil, err
+	}
 	ports, binding, err := nat.ParsePortSpecs(c.Ports)
 	if err != nil {
 		return nil, nil, err

--- a/librcompose/docker/convert_test.go
+++ b/librcompose/docker/convert_test.go
@@ -1,19 +1,14 @@
 package docker
 
 import (
-	"reflect"
 	"testing"
+	"github.com/stretchr/testify/assert"
 	shlex "github.com/flynn/go-shlex"
 )
 
 func TestParseCommand(t *testing.T) {
 	exp := []string{"sh", "-c", "exec /opt/bin/flanneld -logtostderr=true -iface=${NODE_IP}"}
 	cmd, err := shlex.Split("sh -c 'exec /opt/bin/flanneld -logtostderr=true -iface=${NODE_IP}'")
-	switch {
-	case err != nil:
-		t.Errorf("Error: %v\n", err)
-	case !reflect.DeepEqual(cmd, exp):
-		t.Errorf("got: %v\n", cmd)
-		t.Errorf("expected: %v\n", exp)
-	}
+	assert.Nil(t, err)
+	assert.Equal(t, exp, cmd)
 }

--- a/librcompose/docker/convert_test.go
+++ b/librcompose/docker/convert_test.go
@@ -1,0 +1,19 @@
+package docker
+
+import (
+	"reflect"
+	"testing"
+	shlex "github.com/flynn/go-shlex"
+)
+
+func TestParseCommand(t *testing.T) {
+	exp := []string{"sh", "-c", "exec /opt/bin/flanneld -logtostderr=true -iface=${NODE_IP}"}
+	cmd, err := shlex.Split("sh -c 'exec /opt/bin/flanneld -logtostderr=true -iface=${NODE_IP}'")
+	switch {
+	case err != nil:
+		t.Errorf("Error: %v\n", err)
+	case !reflect.DeepEqual(cmd, exp):
+		t.Errorf("got: %v\n", cmd)
+		t.Errorf("expected: %v\n", exp)
+	}
+}


### PR DESCRIPTION
Make sure we use an uptodate library (currently, go-shlex) to parse commands.
Also, do not swallow the parsing errors.